### PR TITLE
Updated abstractions.r to fix variable names.

### DIFF
--- a/abstractions.R
+++ b/abstractions.R
@@ -70,7 +70,7 @@ palette <- sample(clpalettes('top'), 1)[[1]]
 colors <- palette %>% swatch %>% .[[1]]
 
 # Do the plot
-ggplot(data = df %>% filter(v>0), aes(x = x, y = y, fill = log(v))) + 
+ggplot(data = df %>% filter(value>0), aes(x = Var1, y = Var2, fill = log(value))) + 
   geom_raster(interpolate = TRUE) +
   coord_equal() +
   scale_fill_gradientn(colours = colors) +


### PR DESCRIPTION
In line 73, 'ggplot(data = df %>% filter(value>0), aes(x = Var1, y = Var2, fill = log(value))) + ', the variables are named incorrectly. The variable names, 'v', 'x', and 'y' variables were renamed to match the column names in the 'df' data frame, which are 'value', 'Var1', and 'Var2', respectively.